### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ UIImage-ASMPDF
 
 A category on UIImage for loading PDFs, inspired by UIImage-PDF. UIImage-ASMPDF functions in much the same way as UIImage-PDF, but simplifies the implementation by removing the need for an extra UIView. UIImage-ASMPDF also allows you to specify a region within the PDF to render into an image, rather than always rendering the entire page. 
 
-### Cocoapods 
+### CocoaPods 
 `pod 'UIImage-ASMPDF'`
 
 ## Usage


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
